### PR TITLE
Update store credit auth amount based on events

### DIFF
--- a/app/models/spree/store_credit.rb
+++ b/app/models/spree/store_credit.rb
@@ -83,8 +83,9 @@ class Spree::StoreCredit < ActiveRecord::Base
 
   def capture(amount, authorization_code, order_currency, options={})
     return false unless authorize(amount, order_currency, action_authorization_code: authorization_code)
+    auth_event = store_credit_events.find_by!(action: AUTHORIZE_ACTION, authorization_code: authorization_code)
 
-    if amount <= amount_authorized
+    if amount <= auth_event.amount
       if currency != order_currency
         errors.add(:base, Spree.t('store_credit_payment_method.currency_mismatch'))
         false
@@ -96,7 +97,7 @@ class Spree::StoreCredit < ActiveRecord::Base
           action_authorization_code: authorization_code,
 
           amount_used: self.amount_used + amount,
-          amount_authorized: self.amount_authorized - amount,
+          amount_authorized: self.amount_authorized - auth_event.amount,
         })
         authorization_code
       end

--- a/app/models/spree/store_credit.rb
+++ b/app/models/spree/store_credit.rb
@@ -41,6 +41,10 @@ class Spree::StoreCredit < ActiveRecord::Base
     Spree::Money.new(amount_used)
   end
 
+  def display_amount_authorized
+    Spree::Money.new(amount_authorized)
+  end
+
   def amount_remaining
     amount - amount_used - amount_authorized
   end

--- a/app/views/spree/admin/store_credits/index.html.erb
+++ b/app/views/spree/admin/store_credits/index.html.erb
@@ -13,6 +13,7 @@
     <thead>
       <th><%= Spree.t("admin.store_credits.credited_html_header").html_safe %></th>
       <th><%= Spree.t("admin.store_credits.used_html_header").html_safe %></th>
+      <th><%= Spree.t("admin.store_credits.authed_html_header").html_safe %></th>
       <th><%= Spree.t("admin.store_credits.type_html_header").html_safe %></th>
       <th><%= Spree.t("admin.store_credits.created_by") %></th>
       <th><%= Spree.t("admin.store_credits.issued_on") %></th>
@@ -26,6 +27,9 @@
           </td>
           <td class='align-center'>
             <span><%= store_credit.display_amount_used.to_html %></span>
+          </td>
+          <td class='align-center'>
+            <span><%= store_credit.display_amount_authorized.to_html %></span>
           </td>
           <td class='align-center'>
             <span><%= store_credit.category_name %></span>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,6 +53,7 @@ en:
         back_to_store_credit_list: "Back to store credit list"
         credited_html_header: "Amount<br/>Credited"
         used_html_header: "Amount<br/>Used"
+        authed_html_header: "Amount<br/>Authorized"
         type_html_header: "Credit<br/>Type"
         created_by: "Created By"
         issued_on: "Issued On"


### PR DESCRIPTION
Given the following scenario:

User is given $200 in store credit
User places an order for $100, it is authed but not captured
User places a second order for $100, it is authed but not captured
An item on order 1 is short shipped, at a value of $50
Order 1 is captured

We would want the total authed amount for the store credit to equal $100, which is the amount required to capture Order 2 (discarding the extra $50 of auth originally made for Order 1). Currently it would keep the extra $50 authed for the rest of time. This more closely resembles how credit cards function.

cc @jordan-brough 