### PR TITLE
Check pending payments when validating amounts

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -51,7 +51,7 @@ module SpreeStoreCredits::OrderDecorator
 
       reconcile_with_credit_card(existing_credit_card_payment, remaining_total)
 
-      if payments.valid.sum(:amount) != total
+      if pending_payments.sum(&:amount) != total
         errors.add(:base, Spree.t("store_credit.errors.unable_to_fund")) and return false
       end
     end


### PR DESCRIPTION
If someone voids a payment, this is used in the calculations, and does not work.