### PR TITLE
Fix payment cancellation for pending store credits

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -101,7 +101,7 @@ module SpreeStoreCredits::OrderDecorator
       super
 
       # Free up authorized store credits
-      payments.store_credits.pending.each { |payment| payment.void! }
+      payments.store_credits.pending.each { |payment| payment.void_transaction! }
 
       # payment_state has to be updated because after_cancel on
       # super does an update_column on the payment_state to set

--- a/spec/models/spree/order_decorator_spec.rb
+++ b/spec/models/spree/order_decorator_spec.rb
@@ -468,4 +468,45 @@ describe "Order" do
       expect(subject.display_store_credit_remaining_after_capture.money.cents).to eq (amount_remaining * 100.0)
     end
   end
+
+  context 'when not capturing at order completion' do
+    let!(:store_credit_payment_method) do
+      create(
+        :store_credit_payment_method,
+        auto_capture: false, # not capturing at completion time
+      )
+    end
+
+    describe '#after_cancel' do
+      let(:user) { create(:user) }
+      let!(:store_credit) do
+        create(:store_credit, amount: 100, user: user)
+      end
+      let(:order) do
+        create(
+          :order_with_line_items,
+          user: user,
+          line_items_count: 1,
+          # order will be $20 total:
+          line_items_price: 10,
+          shipment_cost: 10,
+        )
+      end
+
+      before do
+        order.contents.advance
+        order.complete!
+      end
+
+      it 'releases the pending store credit authorization' do
+        expect {
+          order.contents.cancel
+        }.to change {
+          store_credit.reload.amount_authorized
+        }.from(20).to(0)
+
+        expect(store_credit.amount_remaining).to eq 100
+      end
+    end
+  end
 end


### PR DESCRIPTION
This fixes store credit payment cancellation when auto-capture is
turned off.

When auto-capture is turned off an order can be canceled with its
store credit payments "authorized" but not "captured". The old code
was *marking* the payments as voided but not actually voiding them
and releasing the authorization.