### PR TITLE
Update #cancel to void when there is an auth but no capture

### DIFF
--- a/app/models/spree/store_credit_event.rb
+++ b/app/models/spree/store_credit_event.rb
@@ -12,6 +12,14 @@ module Spree
 
     delegate :currency, to: :store_credit
 
+    def capture_action?
+      action == Spree::StoreCredit::CAPTURE_ACTION
+    end
+
+    def authorization_action?
+      action == Spree::StoreCredit::AUTHORIZE_ACTION
+    end
+
     def display_amount
       Spree::Money.new(amount, { currency: currency })
     end

--- a/lib/spree_store_credits/factories.rb
+++ b/lib/spree_store_credits/factories.rb
@@ -55,6 +55,10 @@ FactoryGirl.define do
     factory :store_credit_auth_event do
       action             { Spree::StoreCredit::AUTHORIZE_ACTION }
     end
+
+    factory :store_credit_capture_event do
+      action             { Spree::StoreCredit::CAPTURE_ACTION }
+    end
   end
 
   factory :store_credits_order_without_user, class: Spree::Order do

--- a/spec/models/spree/store_credit_event_spec.rb
+++ b/spec/models/spree/store_credit_event_spec.rb
@@ -34,6 +34,46 @@ describe Spree::StoreCreditEvent do
     end
   end
 
+  describe "#capture_action?" do
+    subject { event.capture_action? }
+
+    context "for capture events" do
+      let(:event) { create(:store_credit_capture_event) }
+
+      it "returns true" do
+        expect(subject).to eq true
+      end
+    end
+
+    context "for non-capture events" do
+      let(:event) { create(:store_credit_auth_event) }
+
+      it "returns false" do
+        expect(subject).to eq false
+      end
+    end
+  end
+
+  describe "#authorization_action?" do
+    subject { event.authorization_action? }
+
+    context "for auth events" do
+      let(:event) { create(:store_credit_auth_event) }
+
+      it "returns true" do
+        expect(subject).to eq true
+      end
+    end
+
+    context "for non-auth events" do
+      let(:event) { create(:store_credit_capture_event) }
+
+      it "returns false" do
+        expect(subject).to eq false
+      end
+    end
+  end
+
   describe "#display_amount" do
     let(:event_amount) { 120.0 }
 


### PR DESCRIPTION
When canceling an order, we want to cancel each payment. Currently spree only cancels "completed" payments during this, but we would want it to cancel "pending" ones as well.

Spree payment methods' #cancel api seems to support:
1) Refunding (crediting) when the payment has already been captured
2) Voiding when the payment has only been authorized
(based on https://github.com/bonobos/spree_gateway/blob/master/app/models/spree/gateway/braintree_gateway.rb#L127)

This gets store credit #cancel closer to this desire.