### PR TITLE
Fix payment bugs

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -33,7 +33,9 @@ module SpreeStoreCredits::OrderDecorator
     def add_store_credit_payments
       payments.store_credits.where(state: 'checkout').map(&:invalidate!)
 
-      remaining_total = outstanding_balance
+      authorized_total = payments.store_credits.pending.sum(:amount)
+
+      remaining_total = outstanding_balance - authorized_total
 
       if user && user.store_credits.any?
         payment_method = Spree::PaymentMethod.find_by_type('Spree::PaymentMethod::StoreCredit')

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -33,6 +33,9 @@ module SpreeStoreCredits::OrderDecorator
     def add_store_credit_payments
       payments.store_credits.where(state: 'checkout').map(&:invalidate!)
 
+      # this can happen when auto capture is off and a user tries to complete an
+      # order and the store credit gets authorized (but not captured) and the
+      # credit card fails.
       authorized_total = payments.store_credits.pending.sum(:amount)
 
       remaining_total = outstanding_balance - authorized_total

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -131,6 +131,8 @@ module SpreeStoreCredits::OrderDecorator
       else
         other_payment.update_attributes!(amount: amount)
       end
+
+      payments.reload
     end
 
     def create_store_credit_payment(payment_method, credit, amount)

--- a/spec/models/spree/order_decorator_spec.rb
+++ b/spec/models/spree/order_decorator_spec.rb
@@ -78,6 +78,7 @@ describe "Order" do
         end
 
         it "charges the outstanding balance to the credit card" do
+          expect(order.errors.messages).to be_empty
           expect(order.payments.count).to eq 1
           expect(order.payments.first.source).to be_a(Spree::CreditCard)
           expect(order.payments.first.amount).to eq order_total
@@ -111,6 +112,7 @@ describe "Order" do
         end
 
         it "creates a store credit payment for the full amount" do
+          expect(order.errors.messages).to be_empty
           expect(order.payments.count).to eq 1
           expect(order.payments.first).to be_store_credit
           expect(order.payments.first.amount).to eq order_total
@@ -148,7 +150,7 @@ describe "Order" do
       end
 
       context "there is a credit card payment" do
-        let!(:cc_payment) { create(:payment, order: order) }
+        let!(:cc_payment) { create(:payment, order: order, amount: order_total) }
 
         before do
           # callbacks recalculate total based on line items
@@ -159,6 +161,7 @@ describe "Order" do
         end
 
         it "charges the outstanding balance to the credit card" do
+          expect(order.errors.messages).to be_empty
           expect(order.payments.count).to eq 2
           expect(order.payments.first.source).to be_a(Spree::CreditCard)
           expect(order.payments.first.amount).to eq expected_cc_total

--- a/spec/models/spree/order_decorator_spec.rb
+++ b/spec/models/spree/order_decorator_spec.rb
@@ -103,7 +103,7 @@ describe "Order" do
 
     context "there is enough store credit to pay for the entire order" do
       let(:store_credit) { create(:store_credit, amount: order_total) }
-      let(:order)        { create(:order, user: store_credit.user, total: order_total) }
+      let(:order) { create(:order_with_totals, user: store_credit.user, line_items_price: order_total).tap(&:update!) }
 
       context "there are no other payments" do
         before do
@@ -139,7 +139,7 @@ describe "Order" do
       let(:order_total) { 500 }
       let(:store_credit_total) { order_total - 100 }
       let(:store_credit)       { create(:store_credit, amount: store_credit_total) }
-      let(:order) { create(:order_with_totals, user: store_credit.user, line_items_price: order_total) }
+      let(:order) { create(:order_with_totals, user: store_credit.user, line_items_price: order_total).tap(&:update!) }
 
       context "there are no other payments" do
         it "adds an error to the model" do
@@ -194,7 +194,7 @@ describe "Order" do
         let(:amount_difference)       { 100 }
         let!(:primary_store_credit)   { create(:store_credit, amount: (order_total - amount_difference)) }
         let!(:secondary_store_credit) { create(:store_credit, amount: order_total, user: primary_store_credit.user, credit_type: create(:secondary_credit_type)) }
-        let(:order)                   { create(:order, user: primary_store_credit.user, total: order_total) }
+        let(:order) { create(:order_with_totals, user: primary_store_credit.user, line_items_price: order_total).tap(&:update!) }
 
         before do
           subject

--- a/spec/models/spree/order_decorator_spec.rb
+++ b/spec/models/spree/order_decorator_spec.rb
@@ -136,11 +136,10 @@ describe "Order" do
     end
 
     context "the available store credit is not enough to pay for the entire order" do
-      let(:expected_cc_total)  { 100.0 }
-      let(:store_credit_total) { order_total - expected_cc_total }
+      let(:order_total) { 500 }
+      let(:store_credit_total) { order_total - 100 }
       let(:store_credit)       { create(:store_credit, amount: store_credit_total) }
-      let(:order)              { create(:order, user: store_credit.user, total: order_total) }
-
+      let(:order) { create(:order_with_totals, user: store_credit.user, line_items_price: order_total) }
 
       context "there are no other payments" do
         it "adds an error to the model" do
@@ -153,18 +152,31 @@ describe "Order" do
         let!(:cc_payment) { create(:payment, order: order, amount: order_total) }
 
         before do
-          # callbacks recalculate total based on line items
-          # this ensures the total is what we expect
-          order.update_column(:total, order_total)
           subject
-          order.reload
         end
 
         it "charges the outstanding balance to the credit card" do
           expect(order.errors.messages).to be_empty
           expect(order.payments.count).to eq 2
           expect(order.payments.first.source).to be_a(Spree::CreditCard)
-          expect(order.payments.first.amount).to eq expected_cc_total
+          expect(order.payments.first.amount).to eq 100
+        end
+
+        # this can happen when auto capture is off and a user tries to complete an
+        # order and the store credit gets authorized (but not captured) and the
+        # credit card fails.
+        context "the store credit is already in the pending state" do
+          before do
+            order.payments.store_credits.last.authorize!
+            order.add_store_credit_payments
+          end
+
+          it "charges the outstanding balance to the credit card" do
+            expect(order.errors.messages).to be_empty
+            expect(order.payments.count).to eq 2
+            expect(order.payments.first.source).to be_a(Spree::CreditCard)
+            expect(order.payments.first.amount).to eq 100
+          end
         end
       end
 

--- a/spec/models/spree/order_decorator_spec.rb
+++ b/spec/models/spree/order_decorator_spec.rb
@@ -162,9 +162,7 @@ describe "Order" do
           expect(order.payments.first.amount).to eq 100
         end
 
-        # this can happen when auto capture is off and a user tries to complete an
-        # order and the store credit gets authorized (but not captured) and the
-        # credit card fails.
+        # see associated comment in order_decorator#add_store_credit_payments
         context "the store credit is already in the pending state" do
           before do
             order.payments.store_credits.last.authorize!


### PR DESCRIPTION
- Fix stale-data bug
- Recognize authorized store credit payments when calculating amounts

These were resulting in bogus "Unable to pay for order using store credits" errors which left users stuck in the "payment" state without being able to progress.

Also:  Make some specs more reliable.

After this is merged I'll submit the same code to solidus.

https://bonobos.atlassian.net/browse/ENG-2280